### PR TITLE
Add benchmarks and operator documentation

### DIFF
--- a/benchmarks/osworld.md
+++ b/benchmarks/osworld.md
@@ -1,0 +1,51 @@
+# OSWorld
+
+OSWorld is a first-of-its-kind scalable, real computer environment for multimodal agents, supporting task setup, execution-based evaluation, and interactive learning across operating systems.
+
+## Key Features
+
+- Scalable computer environment supporting multiple operating systems (Ubuntu, Windows, macOS)
+- Unified environment for evaluating open-ended computer tasks
+- Supports arbitrary applications and cross-app workflows
+- Includes 369 real-world computer tasks with reliable setup and evaluation scripts
+- Enables interactive learning and evaluation
+
+## Performance Metrics
+
+Current performance benchmarks:
+- Human performance: >72.36% task success rate
+- Best model performance: 12.24% success rate
+- Models primarily struggle with GUI grounding and operational knowledge
+
+## Task Categories
+
+Tasks span multiple domains including:
+- Web applications
+- Desktop applications
+- OS file I/O operations
+- Cross-application workflows
+- Real-world use cases
+
+## Technical Infrastructure
+
+- Uses configuration files for task initialization
+- Supports agent interaction and post-processing
+- Enables file and information retrieval
+- Includes execution-based evaluation functions
+- Supports parallel environment execution
+- Enables headless operation
+
+## Key Statistics
+
+- Total tasks: 369 (plus 43 additional Windows-based tasks)
+- Execution-based evaluation functions: 134
+- Supports intermediate initialization states
+- Enables multimodal interaction
+- Allows cross-app task execution
+
+## References
+
+- Paper: https://arxiv.org/abs/2404.07972
+- Website: https://os-world.github.io/
+- Code: https://github.com/xlang-ai/OSWorld
+- Documentation: https://timothyxxx.github.io/OSWorld/

--- a/benchmarks/webarena.md
+++ b/benchmarks/webarena.md
@@ -1,0 +1,40 @@
+# WebArena
+
+WebArena is a realistic web environment for building autonomous agents. It creates websites from popular categories with functionality and data mimicking their real-world equivalents.
+
+## Key Features
+
+- Standalone, self-hostable web environment for building autonomous agents
+- Creates websites from four popular categories with realistic functionality
+- Embeds tools and knowledge resources as independent websites
+- Provides annotated programs for programmatically validating task correctness
+- Supports task setup and execution-based evaluation
+
+## Performance Metrics
+
+Based on recent evaluations:
+- GPT-4 achieves 58% accuracy using only the GUI interface
+- Supports evaluation through both information seeking tasks and programmatic checking of intermediate states
+
+## Task Categories
+
+WebArena includes tasks across various domains including:
+- Web navigation
+- Online shopping
+- Table booking
+- Information seeking
+- Multi-step workflows
+
+## Technical Details
+
+- Provides a controlled web environment
+- Supports multimodal agent evaluation
+- Enables cross-app interactions
+- Allows starting tasks from intermediate states
+- Includes execution-based evaluation functions
+
+## References
+
+- Paper: https://arxiv.org/pdf/2307.13854
+- Website: https://webarena.dev
+- Code: https://github.com/web-arena-x/webarena

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -1,0 +1,60 @@
+# OpenAI Operator
+
+Based on the recent announcements and discussions, here are the key details about OpenAI's Operator.
+
+## Overview
+
+Operator is a web navigation and task automation tool that interacts directly through mouse clicks and screenshots using a new model called CUA (Computer Use Assistant).
+
+## Key Features
+
+### Interface & Interaction
+- Uses CUA model for direct mouse click and screenshot interaction
+- Similar approach to Anthropic's Computer Use capability
+- Includes "take over control" feature allowing users to stop and complete tasks manually
+- Actions are not visible to Operator - users need to communicate changes
+
+### Safety Features
+1. Task Filtering
+   - Refuses harmful tasks
+   - Blocks particular websites
+   - Asks for confirmation for potentially risky actions
+
+2. Monitoring
+   - Combines model alignment training with post-hoc detection
+   - Monitors for unsafe behaviors
+   - Includes confirmation mode (similar to OpenHands)
+
+### Performance
+- Benchmarked on standard evaluation frameworks:
+  - OSWorld: ~30% accuracy
+  - WebArena: 58% accuracy using only GUI interface
+  - Performs better than published results on these benchmarks
+
+### Current Scope
+- Currently focused on web interactions only
+- Less expansive than initially expected (no full MacOS integration)
+- Polished user interface comparable to OpenHands and other alternatives like MultiOn
+
+## Technical Details
+- Uses screenshot-based interaction
+- No access to accessibility tree or text modality
+- Direct mouse control through CUA model
+- Includes safety monitoring and confirmation systems
+
+## Limitations
+- Web-only functionality
+- Requires user communication for non-visible actions
+- Limited to browser-based tasks
+
+## Future Potential
+- May help increase awareness of agent capabilities
+- Could drive community efforts around:
+  - Matching accuracy benchmarks
+  - Improving agent safety
+  - Developing better evaluation metrics
+
+## Related Projects
+- Similar to Anthropic's Computer Use capability
+- Comparable to OpenHands functionality
+- Benchmarked against WebArena and OSWorld standards


### PR DESCRIPTION
This PR adds documentation for benchmarks and OpenAI Operator:

- Add WebArena benchmark documentation with key features, metrics and technical details
- Add OSWorld benchmark documentation covering its capabilities and infrastructure
- Add OpenAI Operator documentation based on recent announcements
- Create organized docs structure with benchmarks/ and docs/ directories

The documentation is based on recent discussions and announcements about these systems.